### PR TITLE
Add: update_cache=yes for Ubuntu 14.04 (Trusty)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  #config.vm.box = "ubuntu/trusty64"
   config.vm.box = "hashicorp/precise64"
 
   config.vm.provision "ansible" do |ansible|

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
+     - trusty
      - precise
      - quantal
      - raring

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install dependencies
   sudo: yes
-  apt: pkg={{ item }} state=present
+  apt: pkg={{ item }} state=present update_cache=yes
   with_items:
     - git
     - curl


### PR DESCRIPTION
Under Ubuntu 14.04 (Trusty), without "apt-get update" beforehand, the following errors will occur:

```
Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.0.1f-1ubuntu2.4_amd64.deb  404  Not Found [IP: 91.189.91.13 80]

E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-doc_1.0.1f-1ubuntu2.4_all.deb  404  Not Found [IP: 91.189.91.13 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```
