### PR TITLE
Add support for RedHat families (RHEL, CentOS, ...)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,10 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "hashicorp/precise64"
+  #config.vm.box = "hashicorp/precise64"
+  #config.vm.box = "chef/centos-6.5"
+  config.vm.box = "chef/centos-7.0"
+
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "test.yml"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,10 @@ galaxy_info:
   - name: Debian
     versions:
      - wheezy
+  - name: EL
+    versions:
+     - 6
+     - 7
   categories:
   - development
   - packaging

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,27 @@
 ---
 - name: Install dependencies
   sudo: yes
-  apt: pkg={{ item }} state=present
+  apt: name={{ item }} state=present update_cache=yes
   with_items:
     - git
     - curl
     - build-essential
     - libssl-dev
   tags: nvm
+  when: ansible_pkg_mgr == "apt"
+
+- name: Install dependencies
+  sudo: yes
+  yum: name={{ item }} state=present
+  with_items:
+    - git
+    - gcc
+    - gcc-c++
+    - make
+    - openssl-devel
+    - libselinux-python
+  tags: nvm
+  when: ansible_pkg_mgr == "yum"
 
 - name: Check for nvm
   remote_user: "{{ nvm.user }}"
@@ -25,6 +39,8 @@
   lineinfile: >
     dest={{ nvm.profile_file }}
     line="source ~{{ nvm.user }}/.nvm/nvm.sh"
+    state=present
+    create=yes
   tags: nvm
 
 - name: Install node


### PR DESCRIPTION
Add support for RedHat families (RHEL, CentOS, ...).

Tested on Vagrant boxes `chef/centos-6.5` & `chef/centos-7.0`.
